### PR TITLE
Add tip about conflicting Gazebo versions

### DIFF
--- a/book/simulation-gazebo.md
+++ b/book/simulation-gazebo.md
@@ -8,6 +8,10 @@ The installation requires to install Gazebo and our simulation plugin.
 
 Follow the instruction in the [sitl_gazebo documentation](https://github.com/px4/sitl_gazebo) to build.
 
+<aside class="tip">
+If you installed a ROS version earlier than Jade, be sure to uninstall the bundled Gazebo (sudo apt-get remove ros-indigo-gazebo) version as it is too old. 
+</aside>
+
 ## Running the Simulation
 
 Run the PX4 SITL with the Iris configuration in the Firmware directory:


### PR DESCRIPTION
I ran into a little problem due to the fact that I had Gazebo2 which was bundled with ROS Indigo. Figured maybe someone else might run into it since Jade is still relatively new.