### PR TITLE
fix mavros offboard docs

### DIFF
--- a/book/ros-mavros-offboard.md
+++ b/book/ros-mavros-offboard.md
@@ -187,5 +187,5 @@ while(ros::ok()){
 The rest of the code is pretty self explanatory. We attempt to switch to offboard mode after which we arm the quad to allow it to fly. In the same loop we continue sending the requested pose at the appropriate rate.
 
 <aside class="tip">
-This code has been simplified to the bare minimum for illustration purposed. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoint.
+This code has been simplified to the bare minimum for illustration purposes. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoint.
 </aside>

--- a/book/ros-mavros-offboard.md
+++ b/book/ros-mavros-offboard.md
@@ -30,11 +30,11 @@ int main(int argc, char **argv)
     ros::NodeHandle nh("~");
 
     ros::Publisher local_pos_pub = nh.advertise<geometry_msgs::PoseStamped>
-            ("/mavros/setpoint_position/local", 1);
+            ("mavros/setpoint_position/local", 10);
     ros::ServiceClient arming_client = nh.serviceClient<mavros_msgs::CommandBool>
-            ("/mavros/cmd/arming");
+            ("mavros/cmd/arming");
     ros::ServiceClient set_mode_client = nh.serviceClient<mavros_msgs::SetMode>
-            ("/mavros/set_mode");
+            ("mavros/set_mode");
 
     mavros_msgs::SetMode offb_set_mode;
     offb_set_mode.request.custom_mode = "OFFBOARD";
@@ -99,11 +99,11 @@ int main(int argc, char **argv)
 The `mavros_msgs` package contains all of the custom messages required to operate services and topics provided by the mavros package. All services and topics as well as their corresponding message types are documented in the [mavros wiki](http://wiki.ros.org/mavros).
 
 ```C++
-ros::Publisher local_pos_pub = nh.advertise<geometry_msgs::PoseStamped>("/mavros/setpoint_position/local", 1);
-ros::ServiceClient arming_client = nh.serviceClient<mavros_msgs::CommandBool>("/mavros/cmd/arming");
-ros::ServiceClient set_mode_client = nh.serviceClient<mavros_msgs::SetMode>("/mavros/set_mode");
+ros::Publisher local_pos_pub = nh.advertise<geometry_msgs::PoseStamped>("mavros/setpoint_position/local", 10);
+ros::ServiceClient arming_client = nh.serviceClient<mavros_msgs::CommandBool>("mavros/cmd/arming");
+ros::ServiceClient set_mode_client = nh.serviceClient<mavros_msgs::SetMode>("mavros/set_mode");
 ```
-We instantiate a publisher to publish the commanded local position and the appropriate clients to request arming and mode change.
+We instantiate a publisher to publish the commanded local position and the appropriate clients to request arming and mode change. Note that for your own system, the "mavros" prefix might be different as it will depend on the name given to the node in it's launch file.
 
 ```C++
 mavros_msgs::SetMode offb_set_mode;
@@ -162,3 +162,7 @@ while(ros::ok()){
 }
 ```
 The rest of the code is pretty self explanatory. We attempt to switch to offboard mode after which we arm the quad to allow it to fly. In the same loop we continue sending the requested pose at the appropriate rate.
+
+<aside class="tip">
+This code has been simplified to the bare minimum for illustration purposed. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoint.
+</aside>

--- a/book/ros-mavros-offboard.md
+++ b/book/ros-mavros-offboard.md
@@ -72,14 +72,12 @@ int main(int argc, char **argv)
             if(set_mode_client.call(offb_set_mode) &&
                     offb_set_mode.response.success){
                 ROS_INFO("Offboard enabled");
-                offboard_enabled = true;
             }
         } else {
             if(!current_state.armed){
                 if(arming_client.call(arm_cmd) &&
                         arm_cmd.response.success){
                     ROS_INFO("Vehicle armed");
-                    armed = true;
                 }
             }
         }
@@ -154,7 +152,7 @@ for(int i = 100; ros::ok() && i > 0; --i){
     ros::spinOnce();
     rate.sleep();
 }
-``` 
+```
 Before entering offboard mode, you must have already started streaming setpoints otherwise the mode switch will be rejected. Here, 100 was chosen as an arbitrary amount.
 
 ```C++


### PR DESCRIPTION
To address #29 
* cleaned topic names
* add some tips to offboard control
* use mavros/state topic to check connection, offboard mode and arming status

@vooon Turns out the reason why I needed to subscribe to global topic `/mavros` instead of `mavros` was because I had declared the node handle with the private initialization `ros::Nodehandle nh("~")`

Code tested and working in SITL.