### PR TITLE
add jdk prerequisites

### DIFF
--- a/book/simulation-prerequisites.md
+++ b/book/simulation-prerequisites.md
@@ -16,7 +16,7 @@ brew install ant
 <div class="host-code"></div>
 
 ```sh
-sudo apt-get install ant
+sudo apt-get install ant openjdk-7-jdk openjdk-7-jre
 ```
 
 ## Windows


### PR DESCRIPTION
After test, on the ubuntu 15.10 should be:
sudo apt-get install ant openjdk-7-jdk openjdk-7-jre