### PR TITLE
added missing packages for compiling the gazebo simulation on linux

### DIFF
--- a/book/simulation-gazebo.md
+++ b/book/simulation-gazebo.md
@@ -35,6 +35,12 @@ brew install gazebo7
 
 [Linux installation instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&ver=6.0&cat=install) for Gazebo 6.
 
+Additionally needed:
+
+```sh
+sudo apt-get install libeigen3-dev protobuf-compiler
+```
+
 ## Running the Simulation
 
 Run the PX4 SITL with the Iris configuration in the Firmware directory:


### PR DESCRIPTION
These were missing for me on a fresh Ubuntu 14.04 after installing gazebo and only the simulation toolchain.
Or should the deps go somewhere else? There is also a "simulation toolchain" section further at the beginning