### PR TITLE
Update architecture-daemon.md

### DIFF
--- a/book/architecture-daemon.md
+++ b/book/architecture-daemon.md
@@ -1,6 +1,6 @@
 # Daemons
 
-A daemon is a process running in the background. In NuttX a daemon process is a task, in POSIX (Linux / Mac OS a daemon is a thread).
+A daemon is a process running in the background. In NuttX a daemon process is a task, in POSIX (Linux / Mac OS) a daemon is a thread.
 
 New daemons are created through the `px4_task_spawn()` command.
 


### PR DESCRIPTION
Symbol error on:
"in POSIX (Linux / Mac OS a daemon is a thread)."
Should be replaced by
"in POSIX (Linux / Mac OS) a daemon is a thread."