### PR TITLE
added pages for Docker, Jenkins, and integration testing. updated ROS…

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -28,6 +28,7 @@ This is the summary of the PX4 dev guide.
   * [Gazebo Simulation](simulation-gazebo.md)
   * [HITL Simulation](simulation-hitl.md)
   * [Interfacing to ROS](simulation-ros-interface.md)
+  * [Testing](simulation-testing.md)
 * Autopilot Hardware
   * [Snapdragon Flight](hardware-snapdragon.md)
   * [Raspberry Pi 2](hardware-pi2.md)
@@ -86,4 +87,6 @@ This is the summary of the PX4 dev guide.
   * [Installing driver for Intel RealSense R200](advanced-realsense_intel.md)
   * [Gimbal Control Setup](advanced-gimbal-control.md)
   * [Switching State Estimators](advanced-switching_state_estimators.md)
+  * [Docker Containers](advanced-docker.md)
+  * [Jenkins Continuous Integration](advanced-jenkins-ci.md)
   * [Licenses](advanced-licenses.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -23,12 +23,12 @@ This is the summary of the PX4 dev guide.
   * [Writing an Application](tutorial-hello-sky.md)
   * [Video streaming in QGC](advanced-videostreaming-qgc.md)
   * [Optical flow and LIDAR-Lite](flow_lidar_inav_setup.md)
+  * [Integration Testing](tutorial-integration-testing.md)
 * Simulation
   * [Basic Simulation](simulation-sitl.md)
   * [Gazebo Simulation](simulation-gazebo.md)
   * [HITL Simulation](simulation-hitl.md)
   * [Interfacing to ROS](simulation-ros-interface.md)
-  * [Testing](simulation-testing.md)
 * Autopilot Hardware
   * [Snapdragon Flight](hardware-snapdragon.md)
   * [Raspberry Pi 2](hardware-pi2.md)

--- a/book/advanced-docker.md
+++ b/book/advanced-docker.md
@@ -1,0 +1,94 @@
+# PX4 Docker Containers
+
+Docker containers are available that contain the complete PX4 development toolchain including Gazebo and ROS simulation:
+
+  * **px4io/px4-dev**: toolchain including simulation
+  * **px4io/px4-dev-ros**: toolchain including simulation and ROS (incl. MAVROS)
+
+Dockerfiles and README can be found here: https://github.com/PX4/containers/tree/master/docker/px4-dev
+
+They are build automatically on Docker Hub: https://hub.docker.com/u/px4io/
+
+## Prerequisites
+
+Install Docker from here https://docs.docker.com/installation/, preferably use one of the Docker-maintained package repositories to get the latest version.
+
+Containers are currently only supported on Linux. If you don't have Linux you can run the container inside a virtual machine, see further down for more information. Do not use `boot2docker` with the default Linux image because it contains no X-Server.
+
+## Use the Docker container
+
+The following will run the Docker container including support for X forwarding which makes the simulation GUI available from inside the container. It also maps the directory `<local_src>` from your computer to `<container_src>` inside the container. Please see the Docker docs for more information on volume and network port mapping.
+
+With the `-–privileged` option it will automatically have access to the devices on your host (e.g. a joystick and GPU). If you connect/disconnect a device you have to restart the container.
+
+```sh
+# enable access to xhost from the container
+xhost +
+
+docker run -it --privileged \
+    -v <local_src>:<container_src>:rw \
+    -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+    -e DISPLAY=:0 \
+    --name=container_name px4io/px4-dev bash
+```
+
+If everything went well you should be in a new bash shell now. Verify if everything works by running SITL for example:
+
+```sh
+cd <container_src>
+make posix_sitl_default gazebo
+```
+
+If you exit the container, your changes are left in this container. The above “docker run” command can only be used to create a new container. To get back into this container simply do:
+
+```sh
+# start the container
+sudo docker start container_name
+# open a new bash shell in this container
+sudo docker exec -it container_name bash
+```
+
+If you need multiple shells connected to the container, just open a new shell and execute that last command again. 
+
+## Virtual machine support
+
+Any recent Linux distribution should work.
+
+The following configuration is tested:
+
+  * OS X with VMWare Fusion and Ubuntu 14.04 (Docker container with GUI support on Parallels make the X-Server crash).
+
+**Memory**
+
+Use at least 4GB memory for the virtual machine.
+
+**Compilation problems**
+
+If compilation fails with errors like this:
+
+```
+The bug is not reproducible, so it is likely a hardware or OS problem.
+c++: internal compiler error: Killed (program cc1plus)
+```
+
+Try disabling parallel builds.
+
+**Allow Docker Control from the VM Host**
+
+Edit `/etc/defaults/docker` and add this line:
+
+```
+DOCKER_OPTS="${DOCKER_OPTS} -H unix:///var/run/docker.sock -H 0.0.0.0:2375"
+```
+
+You can then control docker from your host OS:
+
+```sh
+export DOCKER_HOST=tcp://<ip of your VM>:2375
+# run some docker command to see if it works, e.g. ps
+docker ps
+```
+
+## Legacy
+
+The ROS multiplatform containers are not maintained anymore: https://github.com/PX4/containers/tree/master/docker/ros-indigo

--- a/book/advanced-jenkins-ci.md
+++ b/book/advanced-jenkins-ci.md
@@ -1,0 +1,38 @@
+# Jenkins CI
+
+Jenkins continuous integration server on [SITL01](http://sitl01.dronetest.io/) is used to automatically run integration tests against PX4 SITL.
+
+## Overview
+
+  * Involved components: Jenkins, Docker, PX4 POSIX SITL
+  * Tests run inside [Docker Containers](advanced-docker.md)
+  * Jenkins executes 2 jobs: one to check each PR against master, and the other to check every push on master
+
+## Test Execution
+
+Jenkins uses [run_container.bash](https://github.com/PX4/Firmware/blob/master/integrationtests/run_container.bash) to start the container which in turn executes [run_tests.bash](https://github.com/PX4/Firmware/blob/master/integrationtests/run_tests.bash) to compile and run the tests.
+
+If Docker is installed the same method can be used locally:
+
+```sh
+cd <directory_where_firmware_is_cloned>
+sudo WORKSPACE=$(pwd) ./Firmware/integrationtests/run_container.bash
+```
+
+## Server Setup
+
+### Installation
+
+See setup [script/log](https://github.com/PX4/containers/tree/master/scripts/jenkins) for details on how Jenkins got installed and maintained.
+
+### Configuration
+
+  * Jenkins security enabled
+  * Installed plugins
+    * github
+    * github pull request builder
+    * embeddable build status plugin
+    * s3 plugin
+    * notification plugin
+    * collapsing console sections
+    * postbuildscript

--- a/book/simulation-ros-interface.md
+++ b/book/simulation-ros-interface.md
@@ -38,13 +38,33 @@ sudo apt-get install ros-indigo-gazebo6-plugins
 
 ## Launching Gazebo with ROS wrappers
 
-In case you would like to modify the Gazebo simulation to integrate sensors publishing directly to ROS topics e.g. the Gazebo ROS laser plugin, Gazebo must be launched with the appropriate ROS wrappers. To do this start the simulator with `no_sim=1`:
+In case you would like to modify the Gazebo simulation to integrate sensors publishing directly to ROS topics e.g. the Gazebo ROS laser plugin, Gazebo must be launched with the appropriate ROS wrappers.
+
+There are ROS launch scripts available to run the simulation wrapped in ROS:
+
+  * [posix_sitl.launch](https://github.com/PX4/Firmware/blob/master/launch/posix_sitl.launch): plain SITL launch
+  * [mavros_posix_sitl.launch](https://github.com/PX4/Firmware/blob/master/launch/mavros_posix_sitl.launch): SITL and MAVROS
+
+To run SITL wrapped in ROS the ROS environment needs to be updated, then launch as usual:
+
+```sh
+cd <Firmware_clone>
+source integrationtests/setup_gazebo_ros.bash $(pwd)
+roslaunch px4 posix_sitl.launch
+```
+
+Include one of the above mentioned launch files in your own launch file to run your ROS application in the simulation.
+
+### What's happening behind the scenes
+
+(or how to run it manually)
 
 ```sh
 no_sim=1 make posix_sitl_default gazebo
 ```
 
 This should start the simulator and the console will look like this
+
 
 ```sh
 [init] shell id: 46979166467136
@@ -72,18 +92,12 @@ INFO  Waiting for initial data on UDP. Please start the flight simulator to proc
 Now in a new terminal make sure you will be able to insert the Iris model through the Gazebo menus, to do this set your environment variables to include the appropriate `sitl_gazebo` folders.
 
 ```sh
-# Set the plugin path so Gazebo finds our model and sim
-export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:[PATH_TO_FIRMWARE]/Firmware/Tools/sitl_gazebo/Build
-# Set the model path so Gazebo finds the airframes
-export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:[PATH_TO_FIRMWARE]/Firmware/Tools/sitl_gazebo/models
+cd <Firmware_clone>
+source integrationtests/setup_gazebo_ros.bash $(pwd)
 ```
 
 Now start Gazebo like you would when working with ROS and insert the Iris quadcopter model. Once the Iris is loaded it will automatically connect to the px4 app.
-```sh
-roslaunch gazebo_ros empty_world.launch
-```
 
-Once the simulation has started, an Iris model can either be added manually via the GUI or programmatically like so:
 ```sh
-rosrun gazebo_ros spawn_model -file iris.sdf -sdf -model iris
+roslaunch gazebo_ros empty_world.launch world_name:=$(pwd)/Tools/sitl_gazebo/worlds/iris.world
 ```

--- a/book/simulation-testing.md
+++ b/book/simulation-testing.md
@@ -1,0 +1,112 @@
+# SITL Testing
+
+This is about end to end integration testing. Tests are executed automatically ([Jenkins CI](advanced-jenkins-ci.md))
+
+## ROS / MAVROS Tests
+
+Prerequisites: [ROS and MAVROS installation](simulation-ros-interface.md)
+
+Run the complete MAVROS test suite:
+
+```sh
+cd <Firmware_clone>
+source integrationtests/setup_gazebo_ros.bash $(pwd)
+rostest px4 mavros_posix_tests_iris.launch
+```
+
+Or with GUI to see what's happening:
+
+```sh
+rostest px4 mavros_posix_tests_iris.launch gui:=true headless:=false
+```
+
+### Write a new MAVROS test (Python)
+
+<aside class="note">
+Currently in early stages, more streamlined support for testing (helper classes/methods etc.) to come.
+</aside>
+
+####1.) Create a new test script
+
+Test scripts are located in `integrationtests/python_src/px4_it/mavros/`. See other existing scripts for examples. Also please consult the official ROS documentation on how to use [unittest](http://wiki.ros.org/unittest).
+
+
+Empty test skeleton:
+
+```python
+#!/usr/bin/env python
+# [... LICENSE ...]
+
+#
+# @author Example Author <author@example.com>
+#
+PKG = 'px4'
+
+import unittest
+import rospy
+import rosbag
+
+from sensor_msgs.msg import NavSatFix
+
+class MavrosNewTest(unittest.TestCase):
+    """
+    Test description
+    """
+
+    def setUp(self):
+        rospy.init_node('test_node', anonymous=True)
+        rospy.wait_for_service('mavros/cmd/arming', 30)
+
+        rospy.Subscriber("mavros/global_position/global", NavSatFix, self.global_position_callback)
+        self.rate = rospy.Rate(10) # 10hz
+        self.has_global_pos = False
+
+    def tearDown(self):
+        pass
+
+    #
+    # General callback functions used in tests
+    #
+    def global_position_callback(self, data):
+        self.has_global_pos = True
+
+    def test_method(self):
+        """Test method description"""
+
+        # FIXME: hack to wait for simulation to be ready
+        while not self.has_global_pos:
+            self.rate.sleep()
+
+        # TODO: execute test
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, 'mavros_new_test', MavrosNewTest)
+```
+
+####2.) Run the new test only
+
+```sh
+# Start simulation
+cd <Firmware_clone>
+source integrationtests/setup_gazebo_ros.bash $(pwd)
+roslaunch px4 mavros_posix_sitl.launch
+
+# Run test (in a new shell):
+cd <Firmware_clone>
+source integrationtests/setup_gazebo_ros.bash $(pwd)
+rosrun px4 mavros_new_test.py
+```
+
+####3.) Add new test node to launch file
+
+In `launch/mavros_posix_tests_irisl.launch` add new entry in test group:
+
+```xml
+	<group ns="$(arg ns)">
+		[...]
+        <test test-name="mavros_new_test" pkg="px4" type="mavros_new_test.py" />
+    </group>
+```
+
+Run the comlpete test suite as described above.

--- a/book/starting-installing.md
+++ b/book/starting-installing.md
@@ -10,4 +10,6 @@ The installation of the development environment is covered below:
   * [Linux](starting-installing-linux.md)
   * [Windows](starting-installing-windows.md)
 
+If you're familiar with Docker you can also use one of the prepared containers: [Docker Containers](advanced-docker.md)
+
 Once finished, continue to the [build instructions](starting-building.md).

--- a/book/tutorial-integration-testing.md
+++ b/book/tutorial-integration-testing.md
@@ -1,12 +1,18 @@
-# SITL Testing
+# Integration Testing
 
 This is about end to end integration testing. Tests are executed automatically ([Jenkins CI](advanced-jenkins-ci.md))
 
 ## ROS / MAVROS Tests
 
-Prerequisites: [ROS and MAVROS installation](simulation-ros-interface.md)
+Prerequisites:
 
-Run the complete MAVROS test suite:
+  * [SITL Simulation](simulation-sitl.md)
+  * [Gazebo](simulation-gazebo.md)
+  * [ROS and MAVROS](simulation-ros-interface.md)
+
+### Execute Tests
+
+To run the complete MAVROS test suite:
 
 ```sh
 cd <Firmware_clone>


### PR DESCRIPTION
… wrapper docs and linked Docker from top level installation docs.

@LorenzMeier basic instructions added on how to add a ROS test. We still need to add the infrastructure for non-ROS test types. A general test page linked from the "how to contribute" site would also make sense (that covers integration tests and `make check`)

@andre-nguyen I updated your ROS wrapper docs, it's a bit simpler to use now with the already prepared launch files. Would be great if you could give that a try.