### PR TITLE
escaped bracketed text to make it show up

### DIFF
--- a/book/concept-mixing.md
+++ b/book/concept-mixing.md
@@ -69,22 +69,22 @@ A simple mixer definition begins with:
 	M: <control count>
 	O: <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 
-If <control count> is zero, the sum is effectively zero and the mixer will
-output a fixed value that is <offset> constrained by <lower limit> and <upper
-limit>.
+If `<control count>` is zero, the sum is effectively zero and the mixer will
+output a fixed value that is `<offset>` constrained by `<lower limit>` and `<upper
+limit>`.
 
 The second line defines the output scaler with scaler parameters as discussed
 above. Whilst the calculations are performed as floating-point operations, the
 values stored in the definition file are scaled by a factor of 10000; i.e. an
 offset of -0.5 is encoded as -5000.
 
-The definition continues with <control count> entries describing the control
+The definition continues with `<control count>` entries describing the control
 inputs and their scaling, in the form:
 
 	S: <group> <index> <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 
-The <group> value identifies the control group from which the scaler will read,
-and the <index> value an offset within that group.  These values are specific to
+The `<group>` value identifies the control group from which the scaler will read,
+and the `<index>` value an offset within that group.  These values are specific to
 the device reading the mixer definition.
 
 When used to mix vehicle controls, mixer group zero is the vehicle attitude


### PR DESCRIPTION
Bracketed text outside of blockquotes was being hidden by browsers, which were interpreting it as HTML tags. Escaped the brackets with backticks for inline code formatting.