### PR TITLE
Add controller modules doc to TOC

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -66,6 +66,7 @@
   * [Communication](middleware/modules_communication.md)
   * [Drivers](middleware/modules_driver.md)
   * [Estimators](middleware/modules_estimator.md)
+  * [Controllers](middleware/modules_controller.md)
   * [System](middleware/modules_system.md)
 * [Robotics](robotics/README.md)
   * [Offboard Control from Linux](ros/offboard_control.md)


### PR DESCRIPTION
Adds the controller modules doc to the TOC so that it is built (it was already linked, but content is only built if it is in the TOC). 

@bkueng FYI, we discussed this recently. 